### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Run Bash Script with Secrets
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/DevOps-Challenge-Orgs/sample-project/security/code-scanning/1](https://github.com/DevOps-Challenge-Orgs/sample-project/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow to configure the GITHUB_TOKEN's scope. Since the existing steps only need to check out the repository and run a script (with secrets), they only require read access to repository contents, i.e., `contents: read`. Add the following near the top of the file (at the workflow/root level, after the `name` field and before `on:`). This ensures all jobs inherit these minimal permissions unless overridden. No other functional changes are needed, and no changes to imports/methods are necessary since this is a YAML config file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.

- Chores
  - Updated CI/CD deployment workflow to explicitly set minimal read-only repository access for automation tokens, aligning with security best practices and reducing risk exposure.
  - Clarifies permissions in the pipeline for consistent behavior across environments and improved compliance.
  - No impact on application functionality, UI, or performance; deployments continue to run as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->